### PR TITLE
Addon base to fill with Kitsu functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,147 @@
+
+# Created by https://www.gitignore.io/api/python,pycharm,visualstudiocode
+# Edit at https://www.gitignore.io/?templates=python,pycharm,visualstudiocode
+
+### PyCharm ###
+# Ignore the whole project, we don't want to get IDE settings in our
+# repositories.
+.idea/
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### VisualStudioCode ###
+.vscode/*
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+
+### Documentation build
+docs/**/public
+docs/**/resources
+
+# End of https://www.gitignore.io/api/python,pycharm,visualstudiocode

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,674 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
-Copyright (c) 2021 CGWire
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,42 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTIBILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+bl_info = {
+    "name": "Stax Kitsu Addon",
+    "author": "Félix David",
+    "description": "Kitsu interface for Stax.",
+    "blender": (2, 93, 0),
+    "version": (0, 0, 0),
+}
+
+from pathlib import Path
+import sys
+
+
+# Reference ./python dir into path to consider subfolders as modules
+sys.path.append(str(Path(__file__).parent.joinpath("python")))
+
+
+from .python import stax_kitsu_ui
+
+
+def register():
+    stax_kitsu_ui.register()
+
+
+def unregister():
+    stax_kitsu_ui.unregister()
+
+
+if __name__ == "__main__":
+    register()

--- a/python/blender_kitsu_utils/sequencer.py
+++ b/python/blender_kitsu_utils/sequencer.py
@@ -1,0 +1,458 @@
+from operator import attrgetter
+from pathlib import Path
+from typing import List, Tuple, Union
+
+import bpy
+from bpy.types import MetaSequence, MovieSequence, SoundSequence
+import openreviewio as orio
+
+
+image_files_extensions = frozenset(  # TODO try to make it cross with Stax
+    [
+        ".bmp",
+        ".cin",
+        ".dds",
+        ".dpx",
+        ".exr",
+        ".hdr",
+        ".j2c",
+        ".jp2",
+        ".jpeg",
+        ".jpg",
+        ".pdd",
+        ".png",
+        ".psb",
+        ".psd",
+        ".rgb",
+        ".rgba",
+        ".sgi",
+        ".tga",
+        ".tif",
+        ".tiff",
+        ".tx",
+    ]
+)
+
+sound_files_extensions = frozenset(
+    [
+        ".wav",
+        ".ogg",
+        ".oga",
+        ".mp3",
+        ".mp2",
+        ".ac3",
+        ".aac",
+        ".flac",
+        ".wma",
+        ".eac3",
+        ".aif",
+        ".aiff",
+        ".m4a",
+        ".mka",
+    ]
+)
+
+
+def get_timeline_names_list(project_name: str, timeline_type: str) -> List[str]:
+    """List of available timelines editing to load into sequencer.
+
+    :param project_name: Source project
+    :param timeline_type: Timeline editing type (Assets, Episode, Playlist...)
+    :return: List of timeline names
+    """
+    # TODO
+    # Maybe not needed in this shared module
+    pass
+
+
+def get_channel_names_list(project: str, timeline_name: str) -> List[str]:
+    """List of channels to load into sequencer.
+
+    :param project_name: Source project name
+    :param timeline_name: Timeline name
+    :return: List of timeline names
+    """
+    # TODO
+    # Maybe not needed in this shared module
+    pass
+
+
+def create_shot_stack(
+    channel_name: str,
+    sequences_stack: MetaSequence,
+    kitsu_shot,  # TODO correct typing
+    channel_index=1,
+    frame_start=0,
+) -> MetaSequence:
+    """Create shot stack as metasequence.
+
+    Versions of the shot are appended to this stack.
+
+    :param Channel_name: Channel name
+    :param kitsu_shot: Kitsu shot
+    :param channel_index: Channel to build composable, defaults to 1
+    :param frame_start: First frame of clip's sequence, defaults to 1
+    :return: Created shot stack metasequence
+    """
+    # Stop process if no cut duration for the shot
+    duration = kitsu_shot.duration  # TODO
+    if not duration:
+        raise ValueError(
+            f"Shot {kitsu_shot.get('code')}: 'duration' is None. Fix it in Kitsu before retrying to load."
+        )
+
+    # Build into VSE
+    meta = sequences_stack.sequences.new_meta(
+        get_shot_seq_name(channel_name, kitsu_shot),
+        channel_index,
+        frame_start,
+    )
+
+    meta["stax_meta_usage"] = "Versions"
+    meta[
+        "kitsu_shot"
+    ] = kitsu_shot  # TODO might need to convert into dict, made to keep the reference for publishing and update correct entity
+    meta.frame_final_duration = duration
+
+    # Create empty frames at start and end for annotate drawing
+    for layer in bpy.data.grease_pencils["Annotations"].layers:
+        layer_frames = [frame.frame_number for frame in layer.frames]
+        if meta.frame_final_start not in layer_frames:  # Start
+            layer.frames.new(meta.frame_final_start)
+        if meta.frame_final_end not in layer_frames:  # End
+            layer.frames.new(meta.frame_final_end)
+
+    return meta
+
+
+def create_version_sequence(
+    self,
+    shot_stack: MetaSequence,
+    kitsu_version,  # TODO typing
+    channel_index=None,
+    try_download=False,
+) -> Union[MovieSequence, SoundSequence]:
+    """Create sequence for a given version.
+
+    :param shot_stack: Shot stack to create version into
+    :param kitsu_version: Kitsu version to build
+    :param channel_index: Channel to build composable, defaults to first shot_stack available channel
+    :param try_download: Try to download movie from server
+    """
+    # Build version name
+    version_name = get_version_seq_name(kitsu_version)
+
+    # Sentinel if version already exists
+    existing_versions = [seq.name for seq in shot_stack.sequences]
+    if version_name in existing_versions or f"stax.{version_name}" in existing_versions:
+        return
+
+    version_clip_path = kitsu_version.movie_path  # TODO
+
+    if try_download:
+        if not version_clip_path or (
+            version_clip_path and not Path(version_clip_path).is_file()
+        ):
+            version_clip_path = download_movie_from_kitsu(kitsu_version)  # TODO
+
+    if version_clip_path:
+        version_clip_path = Path(version_clip_path)
+    else:  # Sentinel
+        return
+
+    # Create shot version
+    # ===================
+    if not channel_index:
+        channel_index = len(shot_stack.sequences) + 1
+    frame_start = shot_stack.frame_final_start
+
+    # Set clip time
+    # -----
+    if version_clip_path.suffix.lower() in image_files_extensions:
+        # Image file
+        sequence = shot_stack.sequences.new_image(
+            name=version_name,
+            filepath=str(version_clip_path),
+            channel=channel_index,
+            frame_start=frame_start,
+            fit_method="FIT",
+        )
+    elif version_clip_path.suffix.lower() in sound_files_extensions:
+        # Sound file
+        sequence = shot_stack.sequences.new_sound(
+            name=version_name,
+            filepath=str(version_clip_path),
+            channel=channel_index,
+            frame_start=frame_start,
+        )
+    else:
+        # Create movie sequence, place holder if file doesn't exist
+        sequence = shot_stack.sequences.new_movie(
+            name=version_name,
+            filepath=str(version_clip_path),
+            channel=channel_index,
+            frame_start=frame_start,
+            fit_method="FIT",
+        )
+
+    # -----
+    if not sequence:  # Sentinel
+        return
+
+    # Add media info data to be displayed into UI (optional)
+    sequence["stax_media_info"] = {}  # TODO
+
+    # Add status
+    sequence["current_status"] = build_orio_status(
+        get_kitsu_statuses(),  # TODO
+        kitsu_version.status,  # TODO
+    ).state
+
+    sequence["kitsu_version"] = kitsu_version  # TODO as dict?
+
+    return sequence
+
+
+def update_shots_timeline(
+    kitsu_versions: List[dict], kitsu_shots: List[dict] = None, is_new_versions=True
+):
+    """Update Blender Timeline from existing timeline and with versions.
+
+    Ancient versions to recent versions from bottom to top.
+
+    :param kitsu_versions: Versions of shots from Kitsu
+    :param kitsu_shots: Shots from Kitsu, create non existing shots for versions if provided, else skip version creation
+    :param is_new_versions: Create version above or below the current one. Default as above.
+    :return: Updated OTIO timeline.
+    """
+
+    scene = bpy.context.scene
+    seq_ed = scene.sequence_editor
+    creation_direction = 1 if is_new_versions else -1
+
+    if not kitsu_shots:  # Sentinel
+        kitsu_shots = []
+
+    # Update shots
+    created_sequences = [None] * len(kitsu_versions)
+    for i, version in enumerate(kitsu_versions):
+
+        task_name = ""  # TODO
+        shot_seq_name = get_shot_seq_name(task_name, shot)
+
+        # Find shot
+        shot_seq = seq_ed.sequences.get(shot_seq_name)
+        if not shot_seq:  # Create shot
+
+            shot_offset = 0
+            for shot in kitsu_shots:
+                shot_seq = create_shot_stack(
+                    task_name,
+                    seq_ed,
+                    shot,
+                    scene.tracks.find(task_name) + 1,
+                    shot_offset,
+                )
+                break
+
+            shot_offset += shot.duration  # TODO
+
+        # Sort existing sequences and move down if too many of them
+        previous_versions_count = len(shot_seq.sequences)
+
+        # Build new version track on top of last one
+        if previous_versions_count:
+            sorted_seqs = sorted(
+                shot_seq.sequences, key=attrgetter("channel", "frame_final_start")
+            )
+            reference_sequence = (
+                sorted_seqs[-1] if creation_direction == 1 else sorted_seqs[0]
+            )
+
+        created_sequences[i] = create_version_sequence(
+            shot_seq,
+            version,
+            reference_sequence.channel + creation_direction
+            if previous_versions_count
+            else 1,
+        )
+        # TODO sound for playlists
+
+    return created_sequences
+
+
+def get_shot_seq_name(task_name: str, kitsu_shot) -> str:
+    """Get shot name from task and shot.
+
+    :param task_name: Task name
+    :param kitsu_shot: Kitsu Shot
+    :return: Shot sequence name
+    """
+    return f"{kitsu_shot.name}_{task_name}"
+
+
+def build_orio_status(available_statuses, version_status: dict) -> orio.Status:
+    """Convert production statuses to review statuses, no history, based on current status.
+
+    # TODO this must be discussed more precisely
+
+    :param version_status: Version status to build ORIO status from
+    :return: ORIO status
+    """
+
+    approved_statuses = available_statuses.get("approved")
+    rejected_statuses = available_statuses.get("rejected")
+
+    if version_status in rejected_statuses:
+        orio_status = orio.Status(
+            state="rejected",
+            author="",
+        )
+    elif version_status in approved_statuses:
+        orio_status = orio.Status(
+            state="approved",
+            author="",
+        )
+    else:
+        orio_status = orio.Status(
+            state="waiting review",
+            author="",
+        )
+
+    return orio_status
+
+
+def build_reviews(
+    available_statuses,
+    kitsu_versions,
+    kitsu_notes,
+    cache_dir: Path,
+) -> List[orio.MediaReview]:
+    """Build reviews from versions.
+
+    :param kitsu_versions: Versions to create reviews from.
+    :param kitsu_notes: Notes to create reviews with.
+    :param cache_dir: Directory to build reviews in.
+    :param build_duration: Duration of the process.
+    :return: Created reviews
+    """
+
+    # Create reviews dir
+    if not cache_dir.is_dir():
+        cache_dir.mkdir(parents=True)
+    downloads_dir = Path(cache_dir, "downloads")
+    if not downloads_dir.is_dir():
+        downloads_dir.mkdir(parents=True)
+
+    # Build reviews
+    # =============
+    # Associate notes to related version
+    attachs_to_download = []
+    created_reviews = [None] * len(kitsu_versions)
+    for i, version in enumerate(kitsu_versions):
+
+        if not version:  # Sentinel
+            continue
+
+        for kitsu_note in kitsu_notes:
+            # TODO
+            # If attachment keep the file for later DL
+            attachs_to_download.append(attach_to_dl)
+
+        # Create or Update review
+        # =============
+        created_reviews[i] = edit_review(
+            available_statuses,
+            version,
+        )
+
+        # Start process to download attachments, use subprocess
+        p = Process(
+            target=download_attachements,
+            args=(attachs_to_download),
+        )
+        p.start()
+
+    return created_reviews
+
+
+def edit_review(
+    available_statuses,
+    version,
+) -> orio.MediaReview:
+    """Create or Update review from version data.
+
+    :param version: Version to create the related review
+    :return: Created review
+    """
+    # ===================
+    # Create media review
+    # ===================
+    version_clip_path = version.movie_path  # TODO
+    if not version_clip_path:  # Sentinel
+        return
+
+    orio_review = orio.MediaReview(version_clip_path)
+
+    # Review metadata
+    orio_review.metadata = {}  # Useful to keep needed data
+
+    # Create status
+    # -------------
+    kitsu_status = version.status  # TODO
+    if kitsu_status is None:
+        # TODO raise an error message
+        pass
+    else:
+        orio_review.status = build_orio_status(available_statuses, kitsu_status)
+
+    # Create the contents
+    # ===================
+    kitsu_notes = []  # TODO
+    for note in kitsu_notes:
+
+        # Create image annotations
+        # ------------------------
+        contents_list = []
+        contents_list.append(  # TODO
+            orio.Content.ImageAnnotation(
+                path_to_image=drawing_on_transparent_bg,
+                frame=annot_start_frame,
+                duration=annot_duration,
+            )
+        )
+
+        # TODO Add text contents from comments
+        # -----------------
+        # Single frame
+        if False and one_frame_duration:  # TODO
+            content = orio.Content.TextAnnotation(
+                body=body, frame=match_frames[0], duration=1
+            )
+        # Several frames annotations
+        elif False and several_frames_duration:  # TODO
+            content = orio.Content.TextAnnotation(
+                body=body,
+                frame=match_frames[0],
+                duration=int(match_frames[-1]) - int(match_frames[0]),
+            )
+        else:
+            content = orio.Content.TextComment(body=body)  # TODO
+
+        # Add content to list
+        contents_list.append(content)
+
+        # Create Note if has contents
+        if contents_list:
+            orio_note = orio.Note(
+                author=note.user_name,  # TODO
+                date=note.creation_date.isoformat(),  # TODO
+                contents=contents_list,
+                metadata={},
+                parent_note=previously_created_orio_note,  # TODO if a note is a reply in a thread
+            )
+
+            # Add note to ORIO review
+            orio_review.add_note(orio_note)
+
+    return orio_review

--- a/python/stax_kitsu_ui/__init__.py
+++ b/python/stax_kitsu_ui/__init__.py
@@ -1,0 +1,33 @@
+"""Initialization for the addon."""
+
+# Import to override Stax UI functions
+from .ops import ops_reviews, ops_session, ops_timeline
+from .ui import ui_timeline
+
+
+def register():
+    """Register classes to Blender."""
+    # Set Custom UI and operators
+    ops_reviews.register()
+    ops_session.register()
+    ops_timeline.register()
+
+    ui_timeline.register()
+
+    print(f"Registered Kitsu UI")
+
+
+def unregister():
+    """Unregister classes to Blender."""
+    # Set Custom UI and operators
+    ops_reviews.unregister()
+    ops_session.unregister()
+    ops_timeline.unregister()
+
+    ui_timeline.unregister()
+
+    print(f"Unregistered Kitsu UI")
+
+
+if __name__ == "__main__":
+    register()

--- a/python/stax_kitsu_ui/ops/ops_reviews.py
+++ b/python/stax_kitsu_ui/ops/ops_reviews.py
@@ -1,0 +1,126 @@
+"""Every operator relevant to reviews."""
+
+from multiprocessing import Process
+from pathlib import Path
+
+import bpy
+from bpy.props import StringProperty
+from bpy.utils import register_class, unregister_class
+import stax
+from stax.utils.utils_cache import (
+    get_temp_directory,
+    save_session,
+)
+from stax.utils.utils_core import get_context
+from stax.utils.utils_reviews import (
+    build_media_reviews,
+    build_pending_notes,
+    clear_media_reviews,
+)
+
+
+class STAX_OT_publish_reviews(
+    stax.ops.ops_reviews.STAX_OT_publish_reviews, bpy.types.Operator
+):
+    """Publish reviews of the current session"""
+
+    bl_idname = "scene.publish_reviews"
+    bl_label = "Publish Reviews"
+
+    filter_glob: StringProperty(
+        default="",
+        options={"HIDDEN"},
+    )
+
+    filename_ext = ""
+
+    directory: bpy.props.StringProperty(
+        name="Outdir Path",
+        description="Where reviews will be written",
+        subtype="DIR_PATH",
+    )
+
+    def execute(self, context):
+        """Execute."""
+        scene = context.scene
+        scene.reviews_linked_directory = self.directory
+
+        # Build pending notes
+
+        edited_notes = build_pending_notes()
+
+        #####################
+        # Publishing
+        #####################
+
+        # Export reviews
+        # --------------
+
+        # Run publish reviews
+        # Overriden part
+        p = Process(
+            target=publish_reviews,  # TODO
+            args=(
+                [
+                    # TODO edited_notes is [(media_sequence, linked_orio_review, created_orio_note)]
+                ],
+                Path(get_temp_directory(), "annotations"),
+            ),
+        )
+        p.start()
+
+        #####################
+        # Cleaning
+        #####################
+
+        # Clear review of related media sequences, first element of edited_notes tuple
+        clear_media_reviews([e[0] for e in edited_notes], pending_note_only=True)
+
+        # Close review session
+        context.scene.review_session_active = False
+
+        # Update for new reviews
+
+        # Add notes to review
+        for _media_seq, review, note in edited_notes:
+            review.add_note(note)
+        # Build media reviews in timeline
+        build_media_reviews(
+            [(media_seq, review) for media_seq, review, _note in edited_notes]
+        )
+
+        # Set the picker as default tool back
+        override = get_context("Main", "PREVIEW")
+        bpy.ops.wm.tool_set_by_id(override, name="builtin.sample")
+
+        # Save session and keep this new state as default
+        save_session()
+
+        # Watch any action considered to start the review session
+        bpy.ops.wm.watch_review_start()
+
+        return {"FINISHED"}
+
+
+classes = [STAX_OT_publish_reviews]
+
+
+def register():
+    """Register classes to Blender."""
+    # Unregister native operators for custom behavior
+    unregister_class(stax.ops.ops_reviews.STAX_OT_publish_reviews)
+
+    # Set Custom UI and operators
+    for cls in classes:
+        register_class(cls)
+
+
+def unregister():
+    """Unregister classes to Blender."""
+    # Set back native classes
+    # Unregister Custom Operators
+    for cls in classes:
+        unregister_class(cls)
+
+    # Register Default Operators
+    register_class(stax.ops.ops_reviews.STAX_OT_publish_reviews)

--- a/python/stax_kitsu_ui/ops/ops_session.py
+++ b/python/stax_kitsu_ui/ops/ops_session.py
@@ -1,0 +1,178 @@
+"""Every operator relevant to session."""
+import base64
+
+import bpy
+from bpy.app.handlers import persistent
+from bpy.utils import register_class, unregister_class
+from stax.utils.utils_config import read_user_config, write_user_config
+
+
+def encode_password(password: str) -> str:
+    """Hash a password for storing.
+
+    :param password: String to hash
+    :return: Hashed string
+    """
+
+    return base64.b64encode(password.encode("utf-8")).decode("utf-8")
+
+
+def decode_password(password: str) -> str:
+    """Verify a stored password against one provided by user.
+
+    :param password: String to decode
+    :return: Decoded string
+    """
+
+    return base64.b64decode(password).decode("utf-8") if password else ""
+
+
+def switch_save_credentials(self, _):
+    """Set auto_login to False if save_credentials is False."""
+
+    if not self.save_credentials:
+        self.auto_login = False
+
+    # Save config
+    write_user_config(
+        additional_data={
+            "auto_login": self.auto_login,
+            "save_credentials": self.save_credentials,
+        }
+    )
+
+
+def switch_auto_login(self, _):
+    """Set save_credentials to True if auto_login is True."""
+
+    if self.auto_login:
+        self.save_credentials = True
+
+    # Save config
+    write_user_config(
+        additional_data={
+            "auto_login": self.auto_login,
+            "save_credentials": self.save_credentials,
+        }
+    )
+
+
+class WM_OT_production_manager_authentication(bpy.types.Operator):
+    """Log-in to synchronize Stax with Kitsu"""
+
+    bl_idname = "wm.kitsu_authentication"
+    bl_label = "Kitsu authentication"
+
+    login: bpy.props.StringProperty(name="User")
+    password: bpy.props.StringProperty(
+        name="Password",
+        subtype="PASSWORD",
+    )
+    save_credentials: bpy.props.BoolProperty(
+        name="Save Credentials", update=switch_save_credentials
+    )
+    auto_login: bpy.props.BoolProperty(name="Auto Log In", update=switch_auto_login)
+
+    def invoke(self, context, _):
+        """UI call."""
+        user_prefs = context.scene.user_preferences
+
+        # Read config data
+        config_data = read_user_config()
+
+        # Initialization from user preferences
+        self.login = user_prefs.author_name
+        self.save_credentials = config_data.get("save_credentials", False)
+
+        if self.save_credentials:
+            self.password = decode_password(config_data.get("password", ""))
+            self.auto_login = config_data.get("auto_login", False)
+        else:
+            self.password = ""
+
+        return context.window_manager.invoke_props_dialog(self)
+
+    def execute(self, context):
+        """Execute."""
+        scene = context.scene
+        user_preferences = context.scene.user_preferences
+
+        # Display loading for user
+        if context.window:
+            context.window.cursor_set("WAIT")
+
+        # Update user preferences
+        user_preferences.author_name = self.login
+
+        # Authenticate
+        # TODO
+        if authenticate(self.login, self.password):
+            # Write config
+            write_user_config(
+                additional_data={
+                    "auto_login": self.auto_login,
+                    "password": encode_password(self.password),
+                    "save_credentials": self.save_credentials,
+                }
+            )
+
+            scene.session_logged_in = True
+
+            self.report({"INFO"}, "Authentication Successful")
+        else:
+            self.password = ""
+
+            scene.session_logged_in = False
+
+            self.report({"ERROR"}, "Authentication failed")
+
+        return {"FINISHED"}
+
+
+@persistent
+def auto_login(*kwargs):
+    """Timer function to be run after addon registering.
+
+    Must contain every SP setup functions.
+    """
+    scene = bpy.context.scene
+    user_prefs = scene.user_preferences
+
+    # Read user config
+    config_data = read_user_config()
+
+    # Auto-login
+    if config_data.get("auto_login"):
+        bpy.ops.wm.kitsu_authentication(
+            login=user_prefs.author_name,
+            password=decode_password(config_data.get("password", "")),
+            save_credentials=config_data.get("save_credentials", False),
+            auto_login=True,
+        )
+
+
+classes = [WM_OT_production_manager_authentication]
+
+
+def register():
+    """Register classes to Blender."""
+    # Set Custom UI and operators
+    for cls in classes:
+        register_class(cls)
+
+    # Custom Properties
+    bpy.types.Scene.session_logged_in = bpy.props.BoolProperty(
+        name="Logged in", default=False
+    )
+
+    bpy.app.timers.register(auto_login, first_interval=0)
+
+
+def unregister():
+    """Unregister classes to Blender."""
+    # Set back native classes
+    # Unregister Custom Operators
+    for cls in classes:
+        unregister_class(cls)
+
+    del bpy.types.Scene.session_logged_in

--- a/python/stax_kitsu_ui/ops/ops_timeline.py
+++ b/python/stax_kitsu_ui/ops/ops_timeline.py
@@ -1,0 +1,721 @@
+"""Every operator relevant to timeline."""
+
+from datetime import datetime, timezone
+import functools
+from pathlib import Path
+
+import bpy
+from bpy.app.handlers import persistent
+from bpy.utils import register_class, unregister_class
+from blender_kitsu_utils.sequencer import (
+    build_reviews,
+    create_shot_stack,
+    create_version_sequence,
+    get_channel_names_list,
+    get_timeline_names_list,
+    update_shots_timeline,
+)
+import stax
+import stax.utils.utils_config as utils_config
+from stax.utils.utils_core import get_context
+from stax.utils.utils_reviews import (
+    build_media_reviews,
+)
+from stax.utils.utils_timeline import (
+    get_media_sequence,
+)
+
+from stax_kitsu_ui.utils import (
+    get_session_dir,
+    get_selected_channels_list,
+)
+
+
+counter = 0
+frame_offset = 0
+shots_total = 0
+
+
+class AvailableItem(bpy.types.PropertyGroup):
+    """Item available from Kitsu."""
+
+    name: bpy.props.StringProperty(name="Name")
+    description: bpy.props.StringProperty(name="Description")
+    selected: bpy.props.BoolProperty(name="Selected", default=True)
+
+
+@persistent
+def update_user_timelines_list(self, context):
+    """Update the list of available timelines for the user.
+
+    Also get the tasks is they are some linked.
+
+    :param self: Current operator running this function
+    :param context: Blender context
+    """
+    scene = context.scene
+
+    # Set available timelines
+    scene.available_timelines.clear()
+    timelines_names = get_timeline_names_list(scene.project_name, scene.timeline_type)
+    for t in timelines_names:
+        tl = scene.available_timelines.add()
+        if type(t) is tuple and len(t) > 1:
+            tl.name, tl.description = t
+        else:
+            tl.name = str(t)
+
+    # Set default timeline if field empty or doesn't exist in valid timelines
+    if timelines_names and (
+        not scene.timeline_name or scene.timeline_name not in timelines_names
+    ):
+        scene.timeline_name = scene.available_timelines[0].name
+
+    # Set available shots
+    update_available_shots(self, context)
+
+    # Load tasks
+    user_config = utils_config.read_user_config()
+
+    # Create channels
+    scene.channels_list.clear()
+
+    channels = get_channel_names_list(scene.project_name)
+
+    for channel in channels:
+        new_channel = scene.channels_list.add()
+        new_channel.name = channel
+
+        # Set synchronization state from user config
+        if (
+            user_config.get(scene.project_name)
+            and channel in user_config.get(scene.project_name).keys()
+        ):
+            new_channel.selected = user_config.get(scene.project_name).get(channel)
+
+
+@persistent
+def update_available_shots(self, context):
+    """Update the list of available shots for the user.
+
+    :param self: Current operator running this function
+    :param context: Blender context
+    """
+    scene = context.scene
+
+    # Sentinel for Playlist which don't have shots but only versions
+    # TODO is it the case for Kitsu?
+    if scene.timeline_type == "Playlist":
+        return
+
+    scene.available_shots.clear()
+    kitsu_shots = []  # TODO get_kitsu_shots()
+    for shot in kitsu_shots:
+        sh = scene.available_shots.add()
+        sh.name = shot.name  # TODO
+
+
+@persistent
+def update_toggle_all_tasks(self, context):
+    """Update the toggle all tasks bool.
+
+    :param self: Current operator running this function
+    :param context: Blender context
+    """
+    scene = context.scene
+    for task in scene.channels_list:
+        task.selected = self.toggle_all_tasks
+
+
+class LoadTimelineBase(bpy.types.Operator):
+    """Load timeline from Kitsu"""
+
+    bl_idname = "sequencer.load_timeline"
+    bl_label = "Load Timeline"
+
+    toggle_all_tasks: bpy.props.BoolProperty(
+        name="Toggle all tasks", update=update_toggle_all_tasks
+    )
+
+    # This parameter is the only required one to target the timeline to load
+    filepath: bpy.props.StringProperty()
+
+    def invoke(self, context, event):
+        """Call when clicking on the Operator through the UI (a.k.a button).
+
+        Native Blender Operator function.
+
+        :param context: Current Blender context
+        :param event: Event that triggered the Operator, can access user inputs (Mouse, keys...)
+        """
+        # Waiting cursor
+        context.window.cursor_set("WAIT")
+
+        return context.window_manager.invoke_props_dialog(self)
+
+    def draw(self, context):
+        """Display the operator's UI after the invoke.
+
+        Native Blender Operator function.
+
+        :param context: Current Blender context
+        """
+        layout = self.layout
+        scene = context.scene
+
+        layout.prop(scene, "timeline_type")
+
+        if scene.timeline_type == "Episode":
+            # Select timeline
+            layout.prop_search(
+                scene, "timeline_name", scene, "available_timelines", text="Episode"
+            )
+
+            # Display description if provided
+            user_timeline = scene.available_timelines.get(scene.timeline_name)
+            if hasattr(user_timeline, "description"):
+                timeline_description = user_timeline.description
+                if timeline_description:
+                    layout.label(text=timeline_description)
+
+            # Select shot to load
+            row = layout.row(align=True)
+            row.prop_search(scene, "shot_to_load", scene, "available_shots")
+            if scene.shot_to_load and scene.shot_to_load != "All":
+                row.prop(scene, "context_shots")
+
+            # Draw project tasks into popup dialog
+            layout.prop(self, "toggle_all_tasks", text="All")
+            for task in reversed(scene.channels_list):
+                layout.prop(task, "selected", text=task.name)
+
+        elif scene.timeline_type == "Asset":
+            layout.label(text="Every asset waiting for your review will be loaded.")
+
+        elif scene.timeline_type == "Playlist":
+            # Select timeline
+            layout.prop_search(
+                scene, "timeline_name", scene, "available_timelines", text="Episode"
+            )
+
+            layout.label(text="All versions from this playlist will be loaded.")
+
+        # Previous versions to load
+        if scene.timeline_type not in ["Playlist"]:
+            layout.prop(scene, "versions_amount")
+
+    def execute(self, context):  # noqa C902
+        """Actual operator execution.
+
+        Native Blender Operator function.
+
+        :param context: Current Blender context
+        """
+        scene = context.scene
+        seq_ed = scene.sequence_editor
+
+        # Keep update date
+        current_update_date = datetime.now(timezone.utc).isoformat()
+
+        # Get timeline cache dir
+        session_dir = get_session_dir()
+        if not session_dir.is_dir():
+            session_dir.mkdir(parents=True)
+
+        global counter
+        global frame_offset
+
+        # Reset timeline if remaining sequences
+        if len(seq_ed.sequences) > 0:
+            scene.sequence_editor_clear()
+            scene.sequence_editor_create()
+
+            counter = 0
+            frame_offset = 0
+
+        # Remove tracks
+        if len(scene.tracks) > 0:
+            scene.tracks.clear()
+
+        # Start Timeline and reviews creation in parallel
+
+        # Get Kitsu shots
+        # TODO Filter shots if only some are asked using scene.shot_to_load and scene.context_shots
+        kitsu_shots = []  # TODO
+
+        # Create channels
+        selected_channels = get_selected_channels_list()
+        for channel in selected_channels:
+            scene.tracks.add().name = channel
+
+        # Get Kitsu versions
+        kitsu_versions = []  # TODO
+
+        # Generate and fill mapping
+        # TODO this part is a bit tricky because designed to have a progressive loading and not freeze the whole UI too long.
+        #       The user can keep an eye on what's going on.
+        tasks_total = len(selected_channels)
+        shots_total = len(kitsu_shots)
+        editing_versions_mapping = [(None, None, None)] * tasks_total * shots_total
+        last_versions = [{}] * tasks_total * shots_total
+        scene_frame_end = 0
+        version_index = 0
+
+        # Create reversed channels to create most recent items channel first
+        for i, channel in reversed(selected_channels):
+            for j, shot in enumerate(kitsu_shots):
+                # Get scene duration, calculate for first loop
+                if i == 0:
+                    scene_frame_end += shot.duration  # TODO
+
+                # Match last version
+                last_version = None  # TODO
+
+                editing_versions_mapping[version_index] = (i, j, last_version)
+                last_versions[version_index] = last_version
+
+                version_index += 1
+
+        # TODO we might want to keep versions python objects for update to avoid downloading them too often.
+        # TODO this case use shelf python module
+
+        # Set range
+        scene.frame_end = scene_frame_end
+
+        # Frame timeline
+        bpy.ops.sequencer.view_all(get_context("Main", "SEQUENCER"))
+
+        # Create timeline
+        bpy.app.timers.register(
+            functools.partial(
+                build_progressive,
+                context,
+                selected_channels,
+                kitsu_shots,
+                editing_versions_mapping,
+                scene.shot_to_load,
+            )
+        )
+
+        # Set fps, remove trailing .0 of floats
+        project = None  # TODO
+        fps = project.fps  # TODO
+        preset_script_path = Path(
+            f"{bpy.utils.preset_paths('framerate')[0]}/{int(fps) if fps % 1 == 0 else fps}.py"
+        )
+        if preset_script_path.is_file():
+            exec(compile(preset_script_path.open().read(), preset_script_path, "exec"))
+        else:
+            self.report(
+                {"WARNING"},
+                f"The preset: '{fps} fps' doesn't exist. Default framerate kept: {scene.render.fps/scene.render.fps_base}.",
+            )
+
+        # Save data
+        scene.stax_info.session_last_update = current_update_date
+
+        # Force color space
+        scene.view_settings.view_transform = "Standard"
+
+        # Set prefetch
+        scene.sequence_editor.use_prefetch = True
+
+        # Enable audio scrubbing
+        scene.use_audio_scrub = True
+
+        # Save session file
+        session_file = session_dir.joinpath(f"{scene.timeline_name}_local").with_suffix(
+            ".blend"
+        )
+
+        # Save session
+        bpy.ops.wm.save_mainfile(filepath=session_file.as_posix())
+
+        return {"FINISHED"}
+
+
+def build_progressive(
+    context, selected_tasks, kitsu_shots, versions_and_reviews, shot_to_load=""
+) -> int:
+    """Build timeline progressively by chunks of shots.
+
+    :param context: Blender Context
+    :param selected_tasks: Tasks to load
+    :param kitsu_shots: Kitsu shots to build
+    :param versions_and_reviews: (versions, reviews) to create
+    :param shot_to_load: Selected shot to load, defaults to ""
+    :return: Next chunk processing delay
+    """
+    if context.screen.is_animation_playing:  # Wait 1 sec if animation playing
+        return 1
+
+    global counter
+    global frame_offset
+
+    scene = context.scene
+    seq_ed = scene.sequence_editor
+
+    # How many versions are added at a time. Enough to keep it fast, not too much to keep reactivity
+    for _ in range(5):
+        # Stopper
+        if counter >= len(versions_and_reviews):
+            # Frame timeline
+            bpy.ops.sequencer.view_all(get_context("Main", "SEQUENCER"))
+
+            # Refresh to empty memory
+            bpy.ops.sequencer.refresh_all()
+
+            bpy.ops.sequencer.select_all(action="DESELECT")
+
+            # Move playhead to selected shot
+            if shot_to_load:
+                for s in scene.sequence_editor.sequences:
+                    if shot_to_load == s.name:
+                        scene.frame_set(s.frame_final_start)
+                        break
+
+            # Set current frame for update
+            scene.frame_set(scene.frame_current)
+
+            return
+
+        # Refresh every 85 versions
+        if counter % 85 == 0:
+            bpy.ops.sequencer.refresh_all()
+
+        # Get version
+        task_index, shot_index, version = versions_and_reviews[counter]
+
+        task_name = selected_tasks[task_index]
+        shot_duration = kitsu_shots[shot_index].duration  # TODO
+
+        # Create version in meta
+        if version:
+
+            # Create shot meta
+            shot_seq = create_shot_stack(
+                task_name,
+                seq_ed,
+                kitsu_shots[shot_index],
+                task_index + 1,
+                frame_offset if shot_index != 0 else 0,
+            )
+
+            # Create version seq
+            version_seq = create_version_sequence(
+                shot_seq,
+                version,
+            )
+
+            if version_seq:
+                # Review is enabled
+                version_seq.lock = (
+                    is_user_authorized_to_review()
+                )  # TODO from gazu directly?
+
+                # Say to build note later when playhead will stop over
+                version_seq["to_build_notes"] = True
+
+            shot_seq.update()
+            shot_seq.frame_final_duration = shot_duration
+
+        # Offset shots
+        if shot_index == 0:  # Reset shot offset
+            frame_offset = shot_duration
+        else:
+            frame_offset += shot_duration
+
+        counter += 1
+
+    return 0
+
+
+class SEQUENCER_OT_update_timeline(bpy.types.Operator):
+    """Update timeline"""
+
+    bl_idname = "sequencer.update_timeline"
+    bl_label = "Update Timeline"
+
+    @classmethod
+    def poll(cls, context):
+        sequence_editor = context.scene.sequence_editor
+        return sequence_editor.sequences and not context.scene.review_session_active
+
+    def execute(self, context):
+        scene = context.scene
+        seq_ed = scene.sequence_editor
+
+        # Keep update date
+        current_update_date = datetime.now(timezone.utc).isoformat()
+        if scene.stax_info.session_last_update:
+            last_update_date = datetime.fromisoformat(
+                scene.stax_info.session_last_update
+            )
+        else:
+            last_update_date = None
+
+        selected_channels_list = get_selected_channels_list()
+
+        # Get timeline cache dir
+        timeline_dir = Path(bpy.data.filepath).parent
+
+        # Get Kitsu shots
+        # TODO Filter shots if only some are asked using scene.shot_to_load and scene.context_shots
+        kitsu_shots = []  # TODO
+
+        # Get updated Kitsu versions from selected_channels_list and kitsu_shots
+        # We might want to get them from cache shelf?
+        kitsu_versions = []  # TODO
+
+        # Get notes of all versions (existing and updated)
+        kitsu_notes = []  # TODO get notes for versions
+
+        if not kitsu_versions and not kitsu_notes:
+            self.report({"INFO"}, "Everything is up-to-date!")
+            return {"CANCELLED"}
+
+        # Create new versions in shots
+        update_shots_timeline(kitsu_versions, kitsu_shots)
+
+        # Create reviews
+
+        created_reviews = build_reviews(
+            available_kitsu_statuses,  # TODO
+            kitsu_versions,
+            kitsu_notes,
+            timeline_dir,
+        )
+
+        # Match sequences and created reviews
+        sequences_and_reviews = []
+        for rev in created_reviews:
+            sequence = seq_ed.sequences_all.get(rev.metadata.get("kitsu_version"))
+            if sequence and (
+                rev.notes or sequence.get("current_status") != rev.status.state
+            ):
+                sequences_and_reviews.append((sequence, rev))
+
+        # Build media reviews in timeline
+        build_media_reviews(sequences_and_reviews)
+
+        scene.stax_info.session_last_update = current_update_date
+
+        # Refresh to empty memory
+        bpy.ops.sequencer.refresh_all()
+
+        self.report({"INFO"}, "Session has been updated!")
+
+        return {"FINISHED"}
+
+
+class SEQUENCER_OT_toggle_meta(bpy.types.Operator):
+    """This operator substitutes sequencer.meta_toggle to exit the active meta if it's a substitute"""
+
+    # TODO Use API when available to override sequencer.meta_toggle directly.
+
+    bl_idname = "sequencer.toggle_meta"
+    bl_label = "Toggle Versions"
+
+    @classmethod
+    def poll(cls, context):
+        sequence_editor = context.scene.sequence_editor
+        return (
+            sequence_editor.active_strip
+            and sequence_editor.active_strip.type == "META"
+            or sequence_editor.meta_stack
+        )
+
+    def execute(self, context):
+        scene = context.scene
+        seq_ed = scene.sequence_editor
+        current_meta = seq_ed.active_strip
+
+        # Exit current meta if active meta is substitute
+        if (
+            not current_meta
+            or current_meta.type != "META"
+            or current_meta.get("stax_kind")
+        ):
+            seq_ed.active_strip = None
+            target_channel = seq_ed.meta_stack[-1].channel
+        else:
+            versions_count = len(current_meta.sequences)
+            if versions_count < scene.versions_amount:
+                # Get kitsu versions TODO make a cache on the meta if it appears too slow
+                kitsu_versions = []  # TODO
+
+                # Build only previous versions from current and with the correct amount
+                missing_versions = []
+                for v in kitsu_versions:
+                    version_name = ""  # TODO
+
+                    if versions_count < scene.versions_amount and (
+                        version_name not in current_meta.sequences
+                        and f"stax.{version_name}" not in current_meta.sequences
+                    ):
+                        missing_versions.append(v)
+
+                        # Move existing versions
+                        for seq in current_meta.sequences:
+                            seq.channel += 1
+
+                        versions_count += 1
+
+                # Update shots
+                update_shots_timeline(missing_versions, is_new_versions=False)
+
+                # Get notes
+                kitsu_notes = []  # TODO
+
+                # Create reviews
+                timeline_dir = Path(bpy.data.filepath).parent
+
+                created_reviews = build_reviews(
+                    available_kitsu_statuses,  # TODO
+                    missing_versions,
+                    kitsu_notes,
+                    timeline_dir,
+                )
+
+                # Match sequences and created reviews
+                sequences_and_reviews = [
+                    (current_meta.sequences.get(related_version_name), rev)  # TODO
+                    for rev in created_reviews
+                    if rev.notes
+                ]
+
+                # Build media reviews in timeline
+                build_media_reviews(sequences_and_reviews)
+
+            # Set target channel
+            seq_ed.active_strip = current_meta
+            target_channel = current_meta.sequences[0].channel
+
+        bpy.ops.sequencer.meta_toggle()
+
+        # Display correct track
+        scene.current_track = str(target_channel)
+
+        return {"FINISHED"}
+
+
+# ======== Handlers ===========
+
+
+@persistent
+def frame_build_review(scene):
+    """Run everytime a frame is changed but the animation is not playing."""
+    if not bpy.context.screen.is_animation_playing:
+        version_seq = get_media_sequence(scene.sequence_editor.active_strip)
+
+        # Flag sentinel
+        if not version_seq or not version_seq.get("to_build_notes"):
+            return
+
+        kitsu_version = version_seq[
+            "kitsu_version"
+        ].to_dict()  # TODO to match kitsu version and its sequence
+        # Get notes
+        last_versions = [kitsu_version]
+        kitsu_notes = []  # TODO
+
+        # Build reviews
+        timeline_dir = Path(bpy.data.filepath).parent
+        created_reviews = build_reviews(
+            available_kitsu_statuses,  # TODO
+            last_versions,
+            kitsu_notes,
+            timeline_dir,
+        )
+
+        # Build media reviews in timeline
+        build_media_reviews([(version_seq, created_reviews[0])])
+
+        # Disable flag
+        version_seq["to_build_notes"] = False
+
+
+classes = [AvailableItem, SEQUENCER_OT_update_timeline, SEQUENCER_OT_toggle_meta]
+
+
+def register():
+    """Register classes to Blender."""
+    # Unregister native operators for custom behavior
+    unregister_class(stax.ops.ops_sequencer.SEQUENCER_OT_toggle_meta)
+
+    # Set Custom UI and operators
+    for cls in classes:
+        register_class(cls)
+
+    # Custom Properties
+    bpy.types.Scene.project_name = bpy.props.StringProperty(
+        name="Project",
+        description="Project Name",
+    )
+    bpy.types.Scene.timeline_type = bpy.props.EnumProperty(
+        name="Entity type",
+        description="What kind of entity do you want to review?",
+        default="Episode",
+        items=[
+            ("Episode", "Episode", "Episode"),
+            ("Asset", "Asset", "Asset"),
+            ("Sequence", "Sequence", "Sequence"),
+            ("Playlist", "Playlist", "Playlist"),
+        ],
+        update=update_user_timelines_list,
+    )
+    bpy.types.Scene.timeline_name = bpy.props.StringProperty(
+        name="Timeline name",
+        description="Choose timeline to load",
+        update=update_available_shots,
+    )
+    bpy.types.Scene.versions_amount = bpy.props.IntProperty(
+        name="Versions to load",
+    )
+
+    bpy.types.Scene.available_timelines = bpy.props.CollectionProperty(
+        type=AvailableItem
+    )
+
+    # Select shots to load
+    # -----
+    bpy.types.Scene.available_shots = bpy.props.CollectionProperty(type=AvailableItem)
+
+    bpy.types.Scene.shot_to_load = bpy.props.StringProperty(
+        name="Shot to load",
+        description="Select one shot to load",
+        default="All",
+    )
+
+    bpy.types.Scene.context_shots = bpy.props.IntProperty(
+        name="Context Shots",
+        description="How many shots before and after",
+        default=1,
+        min=0,
+    )
+    # -----
+
+    bpy.types.Scene.channels_list = bpy.props.CollectionProperty(
+        type=AvailableItem
+    )  # TODO should it be called tasks_list?
+
+    # Set handler
+    bpy.app.handlers.frame_change_post.insert(0, frame_build_review)
+
+
+def unregister():
+    """Unregister classes to Blender."""
+    # Set back native classes
+    # Unregister Custom Operators
+    for cls in classes:
+        unregister_class(cls)
+
+    del bpy.types.Scene.project_name
+    del bpy.types.Scene.timeline_type
+    del bpy.types.Scene.timeline_name
+    del bpy.types.Scene.versions_amount
+    del bpy.types.Scene.available_timelines
+    del bpy.types.Scene.available_shots
+    del bpy.types.Scene.shot_to_load
+    del bpy.types.Scene.context_shots
+    del bpy.types.Scene.channels_list

--- a/python/stax_kitsu_ui/ui/ui_timeline.py
+++ b/python/stax_kitsu_ui/ui/ui_timeline.py
@@ -1,0 +1,58 @@
+"""Every ui functions relative to timeline, only overrides."""
+
+import bpy
+import stax
+
+
+@staticmethod
+def draw_author(layout):
+    """Override from Stax draw_author."""
+    context = bpy.context
+    scene = context.scene
+    user_preferences = scene.user_preferences
+
+    # Log-in Button
+    row = layout.row(align=True)
+    if not scene.session_logged_in:
+        row.operator(
+            "wm.kitsu_authentication",
+            text="Please log-in to Kitsu",
+            icon="USER",
+        )
+    else:
+        row.operator(
+            "wm.kitsu_authentication",
+            text="user : " + user_preferences.author_name,
+            icon="USER",
+        )
+
+        # UI displayed if user logging is successful
+        if scene is bpy.data.scenes["Scene"]:
+            # [] Load timeline
+            row.separator()
+
+            prod_name = "Caminandes"  # TODO
+
+            row.operator(
+                "sequencer.load_timeline",
+                text=f"Load {prod_name} Timeline",
+                icon="ASSET_MANAGER",
+            )
+
+    # Update timeline
+    if scene.timeline_name and scene is bpy.data.scenes["Scene"]:
+        row = layout.row()
+
+        row.operator("sequencer.update_timeline", text="Update", icon="FILE_REFRESH")
+
+
+kept_draw_author = stax.ui.ui_time.TIME_HT_editor_buttons.draw_author
+# ======
+
+
+def register():
+    stax.ui.ui_time.TIME_HT_editor_buttons.draw_author = draw_author
+
+
+def unregister():
+    stax.ui.ui_time.TIME_HT_editor_buttons.draw_author = kept_draw_author

--- a/python/stax_kitsu_ui/utils.py
+++ b/python/stax_kitsu_ui/utils.py
@@ -1,0 +1,49 @@
+"""Utils for all the module."""
+
+from pathlib import Path
+from typing import List
+
+import bpy
+from stax.utils.utils_cache import (
+    get_cache_directory,
+)
+
+
+def get_session_dir() -> Path:
+    """Get session directory.
+
+    :return: Path of session directory
+    """
+    scene = bpy.context.scene
+    return get_cache_directory().joinpath("Sessions", scene.project_name)
+
+
+def get_shots_list() -> List[str]:
+    """Get shots list depending on shots to load if any, with context.
+
+    :return: List of shots asked to be loaded
+    """
+    scene = bpy.context.scene
+
+    # If shots to load, load only shots, else get all shots
+    shots_to_load = scene.available_shots
+    if scene.shot_to_load and scene.shot_to_load != "All":
+        selected_shot_index = scene.available_shots.find(scene.shot_to_load)
+        shots_to_load = scene.available_shots[
+            max(0, selected_shot_index - scene.context_shots) : min(
+                len(scene.available_shots),
+                selected_shot_index + scene.context_shots + 1,
+            )
+        ]
+
+    return [shot.name for shot in shots_to_load if shot.name != "All"]
+
+
+def get_selected_channels_list() -> List[str]:
+    """Get selected channels list to be loaded.
+
+    :return: Channels list
+    """
+    scene = bpy.context.scene
+
+    return [channel.name for channel in scene.channels_list if channel.selected]


### PR DESCRIPTION
- Addon base with main operators for creating and reviewing an editing: 
  - `publish_reviews` stax operator override
  - `kitsu_authentication`
  - `load_timeline`
  - `update_timeline`
  - `toggle_versions`
  - UI override of `draw_author` Stax part to have a login button instead of author field name.

The addon registers but doesn't run. All missing information is indicated with a `# TODO` and sometimes with questions or recommendations. This is a code skeleton then you are free to refactor it. 

The design to build the timeline and fetch the notes is a bit tricky because it's been made to take the less time as possible to have the important info, and ask for more info only when asked by the user (versions, notes...). Feel free to ask if you have any issue with it. I've tried to comment it as much as possible with explanations.

Created a separate `blender_kitsu_utils` module to be able to make it autonomous one day.

You should implement them this is the following order:
1. `kitsu_authentication`
1. `load_timeline`
1. `update_timeline`
1. `toggle_versions`
1. `publish_reviews`